### PR TITLE
Update README for CleanTrashRooms site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
-# Rebow
+# CleanTrashRooms Landing Page
 
-A lightweight starter design system & static site scaffold.
+This repository hosts the CleanTrashRooms marketing site built on the Rebow starter design system.
+
+## Quick start
+
+1. Clone the repository and move into the project directory.
+2. Serve the static files locally (for example, `python3 -m http.server 3000`) to preview the landing page at `http://localhost:3000`.
+3. Update content in `index.html` and replace imagery or styles in the `assets/` directory as needed for marketing updates.
+
+## Deployment notes
+
+The site is designed to be deployed as a static site (e.g., GitHub Pages or any static hosting provider). Ensure the `CNAME` file remains in the project root to preserve the CleanTrashRooms custom domain mapping when deploying.


### PR DESCRIPTION
## Summary
- rename the README title to CleanTrashRooms Landing Page and describe the marketing site purpose
- add quick start and deployment guidance for serving the static site and preserving the custom domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0794b15d083269654f78d80aee413