### PR TITLE
Update hero messaging and CTA labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <div class="site-header__inner container">
       <div class="branding">
         <span class="logo">CleanTrashRooms</span>
-        <p class="tagline">Premium trash room restoration for commercial and multifamily properties.</p>
+        <p class="tagline">Daily professional cleaning for Chicago apartment buildings that keeps trash rooms spotless.</p>
       </div>
       <a class="btn btn-primary" href="#free-quote">Get Your Free Quote</a>
     </div>
@@ -22,16 +22,16 @@
     <section class="hero" id="hero">
       <div class="hero__grid container">
         <div class="hero__content">
-          <h1>CleanTrashRooms</h1>
-          <p class="hero__lead">Eliminate odors, grime, and hazardous buildup in your trash rooms with a specialty team that treats sanitation like a science.</p>
+          <h1>Stop Dealing with Disgusting Trash Rooms</h1>
+          <p class="hero__lead">Daily professional cleaning for Chicago apartment buildings that ends odor complaints, prevents pest issues, and keeps compliance simple.</p>
           <div class="hero__actions">
-            <a class="btn btn-primary" href="#free-quote">Schedule a walkthrough</a>
-            <a class="btn btn-secondary" href="#packages">View service packages</a>
+            <a class="btn btn-primary" href="#free-quote">Get Your Free Quote</a>
+            <a class="btn btn-secondary" href="#showcase">See Results</a>
           </div>
           <ul class="hero__highlights">
-            <li>Certified technicians with hospitality-level standards</li>
-            <li>Hospital-grade sanitizing, deodorizing, and sealing</li>
-            <li>Flexible scheduling that keeps residents happy</li>
+            <li>This isn't a janitor's job—trash rooms need specialists who sanitize, deodorize, and seal every surface.</li>
+            <li>Daily service keeps chutes, compactors, and waste areas spotless for Chicago residents and staff.</li>
+            <li>Detailed reporting proves results and keeps property teams ahead of complaints and inspections.</li>
           </ul>
         </div>
         <figure class="hero__media">


### PR DESCRIPTION
## Summary
- refresh the header tagline and hero headline with new Chicago-focused messaging
- update the hero lead paragraph and highlights to emphasize specialized daily service results
- retitle the primary and secondary hero calls-to-action while keeping their original destinations relevant

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d087a1bbc08326ad323e5a8b319a86