### PR TITLE
Rework specialty comparison content

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -289,35 +289,104 @@ main {
   padding-block: var(--space-3xl);
 }
 
-.comparison-table {
+.specialty-comparison__intro {
+  text-align: center;
   display: grid;
   gap: var(--space-sm);
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
-  overflow: hidden;
+  margin-bottom: var(--space-2xl);
 }
 
-.comparison-table__row {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-sm);
-  padding: var(--space-lg);
-  border-bottom: 1px solid var(--color-border);
+.specialty-comparison__intro h2 {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: clamp(var(--font-size-2xl), 2.4vw + 1rem, var(--font-size-3xl));
 }
 
-.comparison-table__row:last-child {
-  border-bottom: none;
+.specialty-comparison__intro p {
+  margin: 0 auto;
+  max-width: 60ch;
+  color: var(--color-text-muted);
 }
 
-.comparison-table__row--header {
-  background: rgba(31, 122, 140, 0.08);
+.specialty-comparison__highlight {
+  display: inline-block;
+  margin-top: var(--space-sm);
+  padding: var(--space-xxs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  background: rgba(31, 122, 140, 0.14);
+  color: var(--color-primary);
   font-weight: 600;
 }
 
-.comparison-table__cell {
-  color: var(--color-text);
+.specialty-comparison__grid {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.specialty-comparison__column {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl);
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: var(--space-md);
+}
+
+.specialty-comparison__column h3 {
+  margin: 0;
+  font-size: var(--font-size-xl);
+}
+
+.specialty-comparison__column--without {
+  border-top: 4px solid rgba(220, 38, 38, 0.8);
+}
+
+.specialty-comparison__column--with {
+  border-top: 4px solid var(--color-primary);
+}
+
+.specialty-comparison__list {
+  margin: 0;
+  padding-left: var(--space-xl);
+  color: var(--color-text-muted);
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.specialty-comparison__cost {
+  margin: var(--space-sm) 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  font-weight: 600;
+}
+
+.specialty-comparison__cost-label {
   font-size: var(--font-size-sm);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.specialty-comparison__indicator {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px var(--space-sm);
+  border-radius: 999px;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+}
+
+.specialty-comparison__indicator--high {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+}
+
+.specialty-comparison__indicator--low {
+  background: rgba(5, 122, 85, 0.14);
+  color: #047857;
 }
 
 .card-grid--packages {
@@ -484,21 +553,18 @@ main {
     grid-template-columns: 1fr;
   }
 
-  .comparison-table__row {
-    grid-template-columns: 1fr;
+  .specialty-comparison__intro {
+    text-align: left;
+  }
+
+  .specialty-comparison__intro p {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .specialty-comparison__cost {
+    flex-wrap: wrap;
     gap: var(--space-xs);
-  }
-
-  .comparison-table__row--header {
-    display: none;
-  }
-
-  .comparison-table__row:not(.comparison-table__row--header) {
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .comparison-table__row:not(.comparison-table__row--header) .comparison-table__cell:first-child {
-    font-weight: 600;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -120,36 +120,45 @@
 
     <section class="specialty-comparison" id="specialty-service">
       <div class="container">
-        <div class="section-heading">
-          <h2>Why Specialty Service Matters</h2>
-          <p>Compare CleanTrashRooms with traditional janitorial crews.</p>
+        <div class="specialty-comparison__intro">
+          <h2>The Specialty You've Been Looking For</h2>
+          <p>
+            Trash rooms behave more like mechanical spaces than common areas. They demand trained technicians,
+            purpose-built chemistry, and proactive maintenance to avoid escalating repairs.
+            <span class="specialty-comparison__highlight">Prevention is always cheaper than emergency remediation.</span>
+          </p>
         </div>
-        <div class="comparison-table" role="table" aria-label="Specialty service comparison">
-          <div class="comparison-table__row comparison-table__row--header" role="row">
-            <div class="comparison-table__cell" role="columnheader">Service Focus</div>
-            <div class="comparison-table__cell" role="columnheader">CleanTrashRooms</div>
-            <div class="comparison-table__cell" role="columnheader">Basic Janitorial</div>
-          </div>
-          <div class="comparison-table__row" role="row">
-            <div class="comparison-table__cell" role="cell">Trash room expertise</div>
-            <div class="comparison-table__cell" role="cell">Dedicated specialists, trained on chute and compactor systems.</div>
-            <div class="comparison-table__cell" role="cell">Generalists without equipment-specific knowledge.</div>
-          </div>
-          <div class="comparison-table__row" role="row">
-            <div class="comparison-table__cell" role="cell">Sanitization approach</div>
-            <div class="comparison-table__cell" role="cell">EPA-registered disinfectants and sealants tailored to porous surfaces.</div>
-            <div class="comparison-table__cell" role="cell">Mop-and-go cleaning that leaves biofilm behind.</div>
-          </div>
-          <div class="comparison-table__row" role="row">
-            <div class="comparison-table__cell" role="cell">Documentation</div>
-            <div class="comparison-table__cell" role="cell">Photo logs, condition reports, and compliance checklists every visit.</div>
-            <div class="comparison-table__cell" role="cell">Limited proof of work beyond sign-off sheets.</div>
-          </div>
-          <div class="comparison-table__row" role="row">
-            <div class="comparison-table__cell" role="cell">Response time</div>
-            <div class="comparison-table__cell" role="cell">Emergency support within 24 hours.</div>
-            <div class="comparison-table__cell" role="cell">Service availability tied to routine schedules.</div>
-          </div>
+        <div
+          class="specialty-comparison__grid"
+          role="group"
+          aria-label="Comparison of outcomes with and without CleanTrashRooms"
+        >
+          <article class="specialty-comparison__column specialty-comparison__column--without">
+            <h3>Without a Specialty Partner</h3>
+            <ul class="specialty-comparison__list">
+              <li>Reactive cleanup only after odor complaints hit your inbox.</li>
+              <li>Standard janitorial supplies that can't neutralize biofilm or pests.</li>
+              <li>No documentation trail for inspections or ownership updates.</li>
+              <li>Unexpected shutdowns when chute and compactor issues escalate.</li>
+            </ul>
+            <p class="specialty-comparison__cost">
+              <span class="specialty-comparison__cost-label">Total Cost Pressure</span>
+              <span class="specialty-comparison__indicator specialty-comparison__indicator--high">High</span>
+            </p>
+          </article>
+          <article class="specialty-comparison__column specialty-comparison__column--with">
+            <h3>With CleanTrashRooms</h3>
+            <ul class="specialty-comparison__list">
+              <li>Scheduled sanitizing, sealing, and odor control before complaints start.</li>
+              <li>Technicians trained on chute, compactor, and ventilation systems.</li>
+              <li>Photo reports, compliance logs, and recommendations every visit.</li>
+              <li>Consistent resident satisfaction and fewer emergency vendor calls.</li>
+            </ul>
+            <p class="specialty-comparison__cost">
+              <span class="specialty-comparison__cost-label">Total Cost Pressure</span>
+              <span class="specialty-comparison__indicator specialty-comparison__indicator--low">Low</span>
+            </p>
+          </article>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the specialty comparison heading and intro copy with messaging that underscores prevention
- rebuild the comparison content into two columns contrasting life without vs. with CleanTrashRooms, including total cost pressure indicators
- add styling for the new layout and highlight treatment to keep the prevention message prominent on all screen sizes

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d087ac78d88326a4702591925af9de