### PR TITLE
Refresh packages section with new offerings

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,35 +162,55 @@
         </div>
         <div class="card-grid card-grid--packages">
           <article class="card card--package">
-            <h3>Fresh Start</h3>
-            <p class="package-price">Starting at $399 / visit</p>
+            <h3>Daily Reset</h3>
+            <p class="package-price">Starting at $149 / day</p>
             <ul>
-              <li>Monthly deep cleaning</li>
-              <li>Odor neutralization</li>
-              <li>Equipment inspection report</li>
+              <li>Daily trash room disinfecting and deodorizing</li>
+              <li>Liner replacement and bin staging support</li>
+              <li>Quick response touch-ups between hauler visits</li>
             </ul>
-            <a class="btn btn-secondary" href="#free-quote">Request Fresh Start</a>
+            <a class="btn btn-secondary" href="#free-quote">Get Quote for Daily Reset</a>
           </article>
           <article class="card card--package">
-            <h3>Resident Delight</h3>
-            <p class="package-price">Starting at $699 / month</p>
+            <h3>3x Weekly</h3>
+            <p class="package-price">Starting at $429 / month</p>
             <ul>
-              <li>Bi-weekly sanitation visits</li>
-              <li>Enzyme treatments for chutes</li>
-              <li>Quarterly sealing and polishing</li>
+              <li>Three scheduled sanitation visits every week</li>
+              <li>Enzyme chute treatments with each service</li>
+              <li>Weekly condition reporting with action items</li>
             </ul>
-            <a class="btn btn-secondary" href="#free-quote">Request Resident Delight</a>
+            <a class="btn btn-secondary" href="#free-quote">Get Quote for 3x Weekly</a>
           </article>
           <article class="card card--package">
-            <h3>Compliance Guardian</h3>
-            <p class="package-price">Custom pricing</p>
+            <h3>Summer Intensive</h3>
+            <p class="package-price">Starting at $1,199 / program</p>
             <ul>
-              <li>Weekly disinfecting and deodorizing</li>
-              <li>Emergency spill response</li>
-              <li>Detailed compliance documentation</li>
+              <li>High-season deep cleaning and sealing rotation</li>
+              <li>Mid-season odor neutralization reinforcement</li>
+              <li>Post-season reset with documentation package</li>
             </ul>
-            <a class="btn btn-secondary" href="#free-quote">Request Compliance Guardian</a>
+            <a class="btn btn-secondary" href="#free-quote">Plan My Summer Intensive</a>
           </article>
+        </div>
+        <div class="additional-services">
+          <h3>Additional Services</h3>
+          <div class="card-grid card-grid--packages">
+            <article class="card card--package">
+              <h4>Deep Clean</h4>
+              <p class="package-price">$599 per visit</p>
+              <p>Comprehensive pressure washing, degreasing, and sealing for neglected rooms.</p>
+            </article>
+            <article class="card card--package">
+              <h4>Overflow Pickups</h4>
+              <p class="package-price">$129 per call</p>
+              <p>On-demand removal of excess waste and bulky items between scheduled hauls.</p>
+            </article>
+            <article class="card card--package">
+              <h4>Emergency Service</h4>
+              <p class="package-price">$249 dispatch fee</p>
+              <p>Rapid response for spills, leaks, and odor events that can’t wait for the next visit.</p>
+            </article>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- swap package cards to highlight the Daily Reset, 3x Weekly, and Summer Intensive plans with updated pricing, features, and CTAs
- add an Additional Services subsection detailing Deep Clean, Overflow Pickups, and Emergency Service pricing

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d087ae180c83268966cb0cd9fce985